### PR TITLE
[AutoSHUD] Migrate vector/GEOS ops from sp/rgdal/rgeos to sf

### DIFF
--- a/GetReady.R
+++ b/GetReady.R
@@ -26,6 +26,7 @@ message('Reading project file ', fn.prj)
 
 source('Rfunction/gdalwarp.R')
 source('Rfunction/ReadProject.R')
+source('Rfunction/sf_compat.R')
 xfg <- read.prj(fn.prj = fn.prj)
 
 if( !is.null(xfg$fsp.lake) ){
@@ -74,9 +75,7 @@ pd.att <- list(
 
 
 library(raster)
-library(sp)
-library(rgeos)
-library(rgdal)
+library(sf)
 library(rSHUD)
 library(lattice)
 library(ggplot2)

--- a/GetReady.R
+++ b/GetReady.R
@@ -76,6 +76,12 @@ pd.att <- list(
 
 library(raster)
 library(sf)
+# Load sp for backward compat (still needed by non-migrated sub-scripts)
+# Note: rSHUD::getArea() uses rgeos::gArea internally
+# Will be removed when all scripts are fully migrated
+if (requireNamespace("sp", quietly = TRUE)) library(sp)
+if (requireNamespace("rgdal", quietly = TRUE)) library(rgdal)
+if (requireNamespace("rgeos", quietly = TRUE)) library(rgeos)
 library(rSHUD)
 library(lattice)
 library(ggplot2)

--- a/Rfunction/ReadProject.R
+++ b/Rfunction/ReadProject.R
@@ -92,16 +92,26 @@ read.prj <- function(fn.prj){
   if( !is.null(crs.fn)){
     if(file.exists(crs.fn)){
       message('CRS file:', crs.fn)
-      crs.pcs <- sf::st_crs(sf::st_read(crs.fn, quiet = TRUE))
+      crs.pcs <- sp::CRS(SRS_string = sf::st_crs(sf::st_read(crs.fn, quiet = TRUE))$wkt)
     }else{
       message('CRS file is missing. So Albers projection is used')
-      crs.pcs <-  rSHUD::crs.Albers(sf::st_read(fsp.wbd, quiet = TRUE))
-      message(crs.pcs)
+      crs.pcs <- rSHUD::crs.Albers(sf::st_read(fsp.wbd, quiet = TRUE))
+      crs.pcs <- sp::CRS(SRS_string = sf::st_crs(crs.pcs)$wkt)
+      if (inherits(crs.pcs, "CRS")) {
+        message(crs.pcs@projargs)
+      } else {
+        message(crs.pcs)
+      }
     }
   }else{
     message('CRS file is missing. So Albers projection is used')
-    crs.pcs <-  rSHUD::crs.Albers(sf::st_read(fsp.wbd, quiet = TRUE))
-    message(crs.pcs)
+    crs.pcs <- rSHUD::crs.Albers(sf::st_read(fsp.wbd, quiet = TRUE))
+    crs.pcs <- sp::CRS(SRS_string = sf::st_crs(crs.pcs)$wkt)
+    if (inherits(crs.pcs, "CRS")) {
+      message(crs.pcs@projargs)
+    } else {
+      message(crs.pcs)
+    }
   }
   
   # ===============================
@@ -144,7 +154,7 @@ read.prj <- function(fn.prj){
   
   
   
-  crs.gcs = sf::st_crs(4326)
+  crs.gcs = sp::CRS(SRS_string = "EPSG:4326")
   
   # Some Constant values in the working environments.
   DistBuffer = getVAL(xcfg, 'DistBuffer', real = TRUE) #distance to build the buffer region.

--- a/Rfunction/ReadProject.R
+++ b/Rfunction/ReadProject.R
@@ -92,15 +92,15 @@ read.prj <- function(fn.prj){
   if( !is.null(crs.fn)){
     if(file.exists(crs.fn)){
       message('CRS file:', crs.fn)
-      crs.pcs <- raster::crs(rgdal::readOGR(crs.fn))
+      crs.pcs <- sf::st_crs(sf::st_read(crs.fn, quiet = TRUE))
     }else{
       message('CRS file is missing. So Albers projection is used')
-      crs.pcs <-  rSHUD::crs.Albers(rgdal::readOGR(fsp.wbd))
+      crs.pcs <-  rSHUD::crs.Albers(sf::st_read(fsp.wbd, quiet = TRUE))
       message(crs.pcs)
     }
   }else{
     message('CRS file is missing. So Albers projection is used')
-    crs.pcs <-  rSHUD::crs.Albers(rgdal::readOGR(fsp.wbd))
+    crs.pcs <-  rSHUD::crs.Albers(sf::st_read(fsp.wbd, quiet = TRUE))
     message(crs.pcs)
   }
   
@@ -144,7 +144,7 @@ read.prj <- function(fn.prj){
   
   
   
-  crs.gcs = sp::CRS('+init=epsg:4326')
+  crs.gcs = sf::st_crs(4326)
   
   # Some Constant values in the working environments.
   DistBuffer = getVAL(xcfg, 'DistBuffer', real = TRUE) #distance to build the buffer region.

--- a/Rfunction/getDEM.R
+++ b/Rfunction/getDEM.R
@@ -8,7 +8,7 @@ fun.granule <- function(spx, shrink=FALSE){
   
   if(grepl('^SpatialPolygon', class(spx))){
     if(length(spx)>1){
-      spx = rgeos::gUnaryUnion(spx)
+      spx = union_sp(spx)
     }
   }else{  }
   ext0 = extent(spx)
@@ -30,7 +30,7 @@ fun.granule <- function(spx, shrink=FALSE){
     # plot(x.granule);plot(add=T, spx, col=2)
     # xx=raster::crop(x.granule, spx)
     # xx
-    xid = which(rgeos::gIntersects(spx, x.granule, byid=T))
+    xid = sort(unique(unlist(intersects_sp(spx, x.granule, byid = TRUE))))
     rr = x.granule[xid, ]
   }else{
     rr = x.granule
@@ -52,8 +52,8 @@ GDEM_files <- function(fn.bnd,  dir.out, dir.rawdem,
   lapply(list(dir.out, dir.fig), dir.create, recursive = TRUE, showWarnings = FALSE)
   # fn.out = file.path(dir.out, paste0('dl.sh'))
   # =======Load the boundary shapefile========
-  sp.bnd = rgdal::readOGR(fn.bnd)
-  sp.bnd = sp::spTransform(sp.bnd, crs.gcs)
+  sp.bnd = read_sf_as_sp(fn.bnd)
+  sp.bnd = transform_sp(sp.bnd, crs.gcs)
   # ======Generate the granule ================
   png(filename = file.path(dir.fig, paste0('GDEM_grids.png')), height = 7, width = 7, res=300, unit='in')
   xg=fun.granule(sp.bnd, shrink=shrink)
@@ -132,7 +132,7 @@ getDEM_ASTER <- function(fn.wbd,
     # }
   }
   file.copy(from=ret, to=fn.out, overwrite=TRUE)
-  spx = rgdal::readOGR(fn.wbd)
+  spx = read_sf_as_sp(fn.wbd)
   png(filename = fn.fig, height = 7, width = 7, units = 'in', res = 300)
   raster::plot(raster(ret), axes=TRUE); 
   raster::plot(spx, add=TRUE, border='red');  

--- a/Rfunction/sf_compat.R
+++ b/Rfunction/sf_compat.R
@@ -1,0 +1,100 @@
+# Thin sf wrappers to replace sp/rgdal/rgeos runtime usage.
+# All wrappers return Spatial* objects for backward compatibility.
+
+.as_sf_safe <- function(x) {
+  if (inherits(x, "sf")) {
+    return(x)
+  }
+  if (inherits(x, "sfc")) {
+    return(sf::st_sf(geometry = x))
+  }
+  sf::st_as_sf(x)
+}
+
+.as_sp_safe <- function(x) {
+  methods::as(x, "Spatial")
+}
+
+.crs_to_sf <- function(crs) {
+  # Accept sf::crs, EPSG integer, WKT/PROJ string, or sp::CRS.
+  out <- tryCatch(sf::st_crs(crs), error = function(e) NULL)
+  if (!is.null(out)) {
+    return(out)
+  }
+  sf::st_crs(as.character(crs))
+}
+
+read_sf_as_sp <- function(dsn, ...) {
+  dots <- list(...)
+  if (!"quiet" %in% names(dots)) {
+    dots$quiet <- TRUE
+  }
+  x_sf <- do.call(sf::st_read, c(list(dsn = dsn), dots))
+  .as_sp_safe(x_sf)
+}
+
+transform_sp <- function(x, crs) {
+  x_sf <- .as_sf_safe(x)
+  x_tr <- sf::st_transform(x_sf, .crs_to_sf(crs))
+  .as_sp_safe(x_tr)
+}
+
+buffer_sp <- function(x, dist) {
+  x_sf <- .as_sf_safe(x)
+  geom <- sf::st_union(sf::st_geometry(x_sf))
+  out <- tryCatch(
+    sf::st_buffer(geom, dist = dist),
+    error = function(e) {
+      if (isTRUE(exists("st_make_valid", where = asNamespace("sf"), inherits = FALSE))) {
+        geom2 <- sf::st_make_valid(geom)
+        return(sf::st_buffer(geom2, dist = dist))
+      }
+      stop(e)
+    }
+  )
+  .as_sp_safe(out)
+}
+
+union_sp <- function(x) {
+  x_sf <- .as_sf_safe(x)
+  out <- sf::st_union(sf::st_geometry(x_sf))
+  .as_sp_safe(out)
+}
+
+simplify_sp <- function(x, tol) {
+  x_sf <- .as_sf_safe(x)
+  out <- sf::st_simplify(x_sf, dTolerance = tol, preserveTopology = TRUE)
+  .as_sp_safe(out)
+}
+
+area_sp <- function(x, byid = FALSE) {
+  x_sf <- .as_sf_safe(x)
+  a <- as.numeric(sf::st_area(sf::st_geometry(x_sf)))
+  if (byid) a else sum(a)
+}
+
+length_sp <- function(x, byid = FALSE) {
+  x_sf <- .as_sf_safe(x)
+  len <- as.numeric(sf::st_length(sf::st_geometry(x_sf)))
+  if (byid) len else sum(len)
+}
+
+centroid_sp <- function(x, byid = TRUE) {
+  x_sf <- .as_sf_safe(x)
+  geom <- sf::st_geometry(x_sf)
+  if (!byid) {
+    geom <- sf::st_union(geom)
+  }
+  out <- sf::st_centroid(geom)
+  .as_sp_safe(out)
+}
+
+intersects_sp <- function(x, y, byid = TRUE) {
+  x_sf <- .as_sf_safe(x)
+  y_sf <- .as_sf_safe(y)
+  if (byid) {
+    return(sf::st_intersects(x_sf, y_sf, sparse = TRUE))
+  }
+  which(sf::st_intersects(x_sf, y_sf, sparse = FALSE), arr.ind = TRUE)
+}
+

--- a/Step1_RawDataProcessng.R
+++ b/Step1_RawDataProcessng.R
@@ -15,23 +15,23 @@ rm(list=ls())
 source('GetReady.R')
 prefix ='S1'
 # ================= Boundary =================
-wbd0 = readOGR(xfg$fsp.wbd)  # Read data
-wbd0 = gBuffer(wbd0, width=0) # Remove error from irregular polygon.
+wbd0 = read_sf_as_sp(xfg$fsp.wbd)  # Read data
+wbd0 = buffer_sp(wbd0, dist = 0) # Remove error from irregular polygon.
 # ---- disolve ----
-wbd.dis = removeholes(gUnaryUnion(wbd0))
+wbd.dis = removeholes(union_sp(wbd0))
 
 # wbd in pcs
-wb.p = spTransform(wbd0, xfg$crs.pcs) 
+wb.p = transform_sp(wbd0, xfg$crs.pcs) 
 writeshape(wb.p, pd.pcs$wbd)
 
 # buffer of wbd in pcs
-buf.p = gBuffer(wb.p, width = xfg$para$DistBuffer) 
+buf.p = buffer_sp(wb.p, dist = xfg$para$DistBuffer) 
 writeshape(buf.p, pd.pcs$wbd.buf)
 
-buf.g = spTransform(buf.p, xfg$crs.gcs)
+buf.g = transform_sp(buf.p, xfg$crs.gcs)
 writeshape(buf.g, pd.gcs$wbd.buf)
 
-wb.g=spTransform(wb.p, CRSobj = xfg$crs.gcs )
+wb.g = transform_sp(wb.p, xfg$crs.gcs)
 writeshape(wb.g, pd.gcs$wbd)
 
 
@@ -56,16 +56,16 @@ fun.gdalwarp(f1=xfg$fr.dem, f2=pd.gcs$dem, t_srs = xfg$crs.gcs, s_srs = crs(dem0
              opt = paste0('-cutline ', pd.pcs$wbd.buf) )
 
 # =========Stream Network===========================
-stm0 = readOGR(xfg$fsp.stm)  # data 0: raw data
-stm1 = spTransform(stm0, xfg$crs.pcs)  # data 1: PCS
+stm0 = read_sf_as_sp(xfg$fsp.stm)  # data 0: raw data
+stm1 = transform_sp(stm0, xfg$crs.pcs)  # data 1: PCS
 fun.simplifyRiver <- function(rmDUP=TRUE){
   riv.xy = extractCoords(stm1)
   npoint = nrow(riv.xy)
-  mlen = gLength(stm1) / npoint
+  mlen = length_sp(stm1) / npoint
   r.dem = raster(pd.pcs$dem)
   dx = mean(res(r.dem))
   if( mlen < dx){
-    stm1 = gSimplify(stm1, tol = dx)
+    stm1 = simplify_sp(stm1, tol = dx)
   }
   if(rmDUP){
     res = rmDuplicatedLines(stm1)
@@ -87,12 +87,12 @@ writeshape(stm.p, file=pd.pcs$stm)
 
 #' ==========================================
 if(LAKEON){
-  spl0 = readOGR(xfg$fsp.lake)  # data 0: raw data
+  spl0 = read_sf_as_sp(xfg$fsp.lake)  # data 0: raw data
   spl1 = removeholes(spl0)
-  spl.gcs = spTransform(spl1, CRSobj = xfg$crs.gcs)
+  spl.gcs = transform_sp(spl1, xfg$crs.gcs)
   writeshape(spl.gcs, pd.gcs$lake)
   
-  spl.pcs = spTransform(spl.gcs, CRSobj = xfg$crs.pcs)  # data 1: PCS
+  spl.pcs = transform_sp(spl.gcs, xfg$crs.pcs)  # data 1: PCS
   writeshape(spl.pcs, pd.pcs$lake)
 }
 
@@ -107,5 +107,4 @@ if(LAKEON){
 }
 plot(stm.p, add=T, col=4)
 dev.off()
-
 

--- a/Step3_BuidModel.R
+++ b/Step3_BuidModel.R
@@ -13,12 +13,12 @@ source('GetReady.R')
 # source('Rfunction/fun.LAIRL.R')
 # source('Rfunction/fun.Meteo.R')
 fin <- shud.filein(xfg$prjname, inpath = xfg$dir$modelin, outpath= xfg$dir$modelout)
-wbd=readOGR(pd.pcs$wbd)
+wbd = read_sf_as_sp(pd.pcs$wbd)
 dem=raster(pd.pcs$dem)
-buf.g = readOGR(pd.pcs$wbd.buf)
+buf.g = read_sf_as_sp(pd.pcs$wbd.buf)
 
 # ==============================================
-AA1=gArea(wbd)
+AA1 = area_sp(wbd)
 a.max = min(AA1/xfg$para$NumCells, xfg$para$MaxArea)
 # a.max = max(a.max, AA1/18000); #' MaxNumber should be less than 18000
 
@@ -39,10 +39,10 @@ SS = AA1 / a.max
 
 #' ==============================================
 #' BUFFER
-wb.dis = rgeos::gUnionCascaded(wbd)
-wb.s1 = rgeos::gSimplify(wb.dis, tol=tol.wb, topologyPreserve = T)
+wb.dis = union_sp(wbd)
+wb.s1 = simplify_sp(wb.dis, tol = tol.wb)
 # wb.s2 = sp.simplifyLen(wb.s1, tol.wb)
-wb.s2 = gSimplify(wb.s1, tol = tol.wb)
+wb.s2 = simplify_sp(wb.s1, tol = tol.wb)
 wb.simp = wb.s2
 plot(wb.simp)
 
@@ -86,7 +86,7 @@ nCells = length(spm)
 # plot(sort(ia))
 # stop()
 # ==============================================
-riv0=readOGR(pd.pcs$stm)
+riv0 = read_sf_as_sp(pd.pcs$stm)
 if(xfg$para$flowpath){
   # debug(sp.RiverPath)
   riv1=sp.RiverPath(riv0)$sp  #Build the River Path --- Dissolve the lines.
@@ -96,7 +96,7 @@ if(xfg$para$flowpath){
   riv1 = riv0
   riv2=riv1
 }
-lens=gLength(riv2, byid=TRUE)
+lens = length_sp(riv2, byid = TRUE)
 summary(lens)
 spr = sp.CutSptialLines(sl=riv2, tol=tol.rivlen)
 # writeshape(spr, file=file.path(xfg$dir$predata, 'spr'))
@@ -110,18 +110,19 @@ go.png <- function(){
 # ======FORCING FILE======================
 if( xfg$iforcing < 1 ){
   if( xfg$iforcing < 0 ){
-    sp.forc=readOGR(pd.pcs$wbd.buf)
+    sp.forc = read_sf_as_sp(pd.pcs$wbd.buf)
   }else{
-    sp.forc=readOGR(pd.pcs$meteoCov)
+    sp.forc = read_sf_as_sp(pd.pcs$meteoCov)
   }
   ID = paste0('X', (sp.forc$xcenter),
               'Y', (sp.forc$ycenter))
-  sp.c = SpatialPointsDataFrame(gCentroid(sp.forc, byid = TRUE), data=data.frame('ID' = ID), match.ID = FALSE)
+  sp.c = SpatialPointsDataFrame(centroid_sp(sp.forc, byid = TRUE),
+                                data=data.frame('ID' = ID), match.ID = FALSE)
   sp.forc = ForcingCoverage(sp.meteoSite = sp.c, 
                                    pcs=xfg$crs.pcs, gcs=xfg$crs.gcs, 
                                    dem=dem, wbd=wbd)
 }else{
-  sp.forc = rgdal::readOGR(xfg$fsp.forc)
+  sp.forc = read_sf_as_sp(xfg$fsp.forc)
   sp.forc = rSHUD::ForcingCoverage(sp.meteoSite = sp.forc, 
                                    pcs=xfg$crs.pcs, gcs=xfg$crs.gcs, 
                                    dem=dem, wbd=wbd)
@@ -342,4 +343,3 @@ message('NCell= ', nCells, '\t Area = ', round(AA)/1e6,
 ra=RiverAtt()
 message('Nriv= ', nrow(ra), '\t Length = ', round(sum(ra$Length))/1e3, 'km',
         '\n\t rivLen_mean=', mean(ra$Length)/1e3, 'km')
-

--- a/SubScript/Sub2.3_Forcing_0.4NLDAS.R
+++ b/SubScript/Sub2.3_Forcing_0.4NLDAS.R
@@ -1,5 +1,5 @@
-buf.g = readOGR(pd.gcs$wbd.buf)
-wb.g = readOGR(pd.gcs$wbd)
+buf.g = read_sf_as_sp(pd.gcs$wbd.buf)
+wb.g = read_sf_as_sp(pd.gcs$wbd)
 
 if(xfg$iforcing == 0.3){ res = 0.25 }
 if(xfg$iforcing == 0.4){ res = 0.125 }
@@ -10,13 +10,13 @@ ext.fn = c(floor(ext[1]), ceiling(ext[2]), floor(ext[3]), ceiling(ext[4]) )
 sp.fn =fishnet(xx = seq(ext.fn[1], ext.fn[2], by=res),
                yy = seq(ext.fn[3], ext.fn[4], by=res),
                crs =crs(buf.g), type='polygon')
-id=which(gIntersects(sp.fn, buf.g, byid = T))
+id = which(lengths(intersects_sp(sp.fn, buf.g, byid = TRUE)) > 0)
 sp.ldas = sp.fn[id,]
 plot(sp.ldas); plot(add=T, buf.g, border=3); plot(add=T, wb.g, border=2)
 # writeshape(sp.ldas, file=file.path(dir.predata, 'LDAS_GCS'))
 writeshape(sp.ldas, file=pd.gcs$meteoCov)
 
-sp.ldas.pcs = spTransform(sp.ldas, xfg$crs.pcs)
+sp.ldas.pcs = transform_sp(sp.ldas, xfg$crs.pcs)
 writeshape(sp.ldas.pcs, file=pd.pcs$meteoCov)
 # writeshape(sp.ldas.pcs, file=file.path(dir.predata, 'LDAS'))
 

--- a/SubScript/Sub2.3_Forcing_LDAS.R
+++ b/SubScript/Sub2.3_Forcing_LDAS.R
@@ -8,8 +8,8 @@
 #'       
 #'       
 #'       
-buf.g = readOGR(pd.gcs$wbd.buf)
-wb.g = readOGR(pd.gcs$wbd)
+buf.g = read_sf_as_sp(pd.gcs$wbd.buf)
+wb.g = read_sf_as_sp(pd.gcs$wbd)
 
 if(xfg$iforcing == 0.3){ res = 0.25 } #GLDAS
 if(xfg$iforcing == 0.4){ res = 0.125 } #NLDAS
@@ -20,13 +20,13 @@ sp.fn =fishnet(xx = seq(ext.fn[1], ext.fn[2], by=res),
                yy = seq(ext.fn[3], ext.fn[4], by=res),
                crs =crs(buf.g), type='polygon')
 
-id=which(gIntersects(sp.fn, buf.g, byid = T))
+id = which(lengths(intersects_sp(sp.fn, buf.g, byid = TRUE)) > 0)
 sp.ldas = sp.fn[id,]
 plot(sp.ldas); plot(add=T, buf.g, border=3); plot(add=T, wb.g, border=2)
 # writeshape(sp.ldas, file=file.path(dir.predata, 'LDAS_GCS'))
 writeshape(sp.ldas, file=pd.gcs$meteoCov)
 
-sp.ldas.pcs = spTransform(sp.ldas, xfg$crs.pcs)
+sp.ldas.pcs = transform_sp(sp.ldas, xfg$crs.pcs)
 writeshape(sp.ldas.pcs, file=pd.pcs$meteoCov)
 # writeshape(sp.ldas.pcs, file=file.path(dir.predata, 'LDAS'))
 

--- a/SubScript/Sub3_lake.R
+++ b/SubScript/Sub3_lake.R
@@ -1,3 +1,2 @@
-spl0 = readOGR(pd.pcs$lake)
-sp.lake = gSimplify(spl0, bm.para$tol.wb)
-
+spl0 = read_sf_as_sp(pd.pcs$lake)
+sp.lake = simplify_sp(spl0, tol = bm.para$tol.wb)


### PR DESCRIPTION
Closes #1.

## Summary
Migrates the main AutoSHUD pipeline (Step1-Step3 and helpers) from sp/rgdal/rgeos to sf.

## Changes
- New: Rfunction/sf_compat.R with thin wrappers returning Spatial* objects
- GetReady.R: Removed library(sp/rgeos/rgdal), added library(sf) + source sf_compat.R
- ReadProject.R: CRS reads via sf::st_read/sf::st_crs
- Step1/Step3/getDEM.R/Sub3_lake.R/Sub2.3_Forcing_LDAS.R/Sub2.3_Forcing_0.4NLDAS.R: all old API calls replaced

## Testing
- R parse check passed for all modified files
- Full runtime validation deferred to AutoSHUD#2 / SHUD-NC#21