### PR TITLE
fix: replace readOGR/gIntersects with sf equivalents in Step2

### DIFF
--- a/Rfunction/CMFD_readnc.R
+++ b/Rfunction/CMFD_readnc.R
@@ -72,7 +72,7 @@ readnc.CMFD<-function(ncid, varid=NULL,  ext = NULL){
 
 
 initalGrids <- function(fn, vn, pd.gcs, pd.pcs, sp.ldas=NULL, dxy){
-  buf.g = readOGR(pd.gcs$wbd.buf)
+  buf.g = read_sf_as_sp(pd.gcs$wbd.buf)
   ext = extent(buf.g)
   
   fid = nc_open(fn) 
@@ -100,7 +100,7 @@ initalGrids <- function(fn, vn, pd.gcs, pd.pcs, sp.ldas=NULL, dxy){
     sp0.gcs = spTransform(sp.ldas, xfg$crs.gcs)
     sp0.pcs = spTransform(sp.ldas, xfg$crs.pcs)
   }
-  id=which(gIntersects(sp0.gcs, buf.g, byid = T)) 
+  id=which(sf::st_intersects(sf::st_as_sf(sp0.gcs), sf::st_as_sf(buf.g), sparse = FALSE)[, 1])
   writeshape(sp0.gcs[id, ], file = pd.gcs$meteoCov)
   writeshape(sp0.pcs[id, ], file = pd.pcs$meteoCov)
   sitenames = paste0('X', sp0.gcs@data$xcenter, 'Y', sp0.gcs@data$ycenter)

--- a/SubScript/Sub2.2_Landcover_GLC.R
+++ b/SubScript/Sub2.2_Landcover_GLC.R
@@ -21,8 +21,8 @@ fun.gdalcut(f.in = xfg$fn.landuse,
 
 r.lu = raster(pd.pcs$lu.r)
 
-wb.p = readOGR(pd.pcs$wbd)
-stm.p = readOGR(pd.pcs$stm)
+wb.p = read_sf_as_sp(pd.pcs$wbd)
+stm.p = read_sf_as_sp(pd.pcs$stm)
 
 go.plot <- function(){
   tab = read.df('Table/USGS_GLC.csv', sep='\t')[[1]]
@@ -107,4 +107,3 @@ go.plot <- function(){
 # write.df(vtab, file=file.path(xfg$dir$predata,'LANDUSE.csv') )
 # write.table(vtab, file.path(xfg$dir$predata,'LanduseTable.csv'), quote=F, 
 #             col.names = T, row.names = F)
-


### PR DESCRIPTION
## Summary
Replace retired `rgdal::readOGR` and `rgeos::gIntersects` calls in Step2 subscripts with sf-compatible equivalents.

## Changes
- `SubScript/Sub2.2_Landcover_GLC.R`: `readOGR` → `read_sf_as_sp` (lines 24-25)
- `Rfunction/CMFD_readnc.R`: `readOGR` → `read_sf_as_sp` (line 75), `gIntersects` → `sf::st_intersects` (line 103)

## Context
Step1 migration was completed in PRs #4, #5, #6. This PR extends the migration to Step2 subscripts that are exercised by the QHH baseline (soil=HWSD, landuse=USGS_GLC, forcing=CMFD).

## Testing
Will be validated by running `python3 tools/shudnc.py projects/qhh/shud.yaml autoshud --profile baseline` in SHUD-NC.