### PR TITLE
fix: use terra API in raster2Polygon for SpatRaster compat

### DIFF
--- a/Rfunction/raster2Polygon.R
+++ b/Rfunction/raster2Polygon.R
@@ -1,9 +1,9 @@
 
 raster2Polygon <- function(rx){
-  ext= raster::extent(rx)
-  res =raster::res(rx)
+  ext= terra::ext(rx)
+  res =terra::res(rx)
   xx = seq(ext[1], ext[2], res[1])
   yy = seq(ext[3], ext[4], res[2])
-  spx = rSHUD::fishnet(xx=xx, yy=yy, crs=raster::crs(rx))
+  spx = rSHUD::fishnet(xx=xx, yy=yy, crs=terra::crs(rx))
   return(spx)
 }


### PR DESCRIPTION
## Summary
`rSHUD::xyz2Raster()` (v2.1.0) now returns `SpatRaster` (terra) instead of `RasterLayer` (raster). `raster2Polygon.R` used `raster::extent/res/crs` which have no method for `SpatRaster`.

## Changes
- `Rfunction/raster2Polygon.R`: `raster::extent` → `terra::ext`, `raster::res` → `terra::res`, `raster::crs` → `terra::crs`

## Testing
Validated by running QHH baseline Step2 CMFD forcing pipeline.