### PR TITLE
fix: handle empty CRS from xyz2Raster in raster2Polygon

### DIFF
--- a/Rfunction/raster2Polygon.R
+++ b/Rfunction/raster2Polygon.R
@@ -4,6 +4,8 @@ raster2Polygon <- function(rx){
   res =terra::res(rx)
   xx = seq(ext[1], ext[2], res[1])
   yy = seq(ext[3], ext[4], res[2])
-  spx = rSHUD::fishnet(xx=xx, yy=yy, crs=terra::crs(rx))
+  crs_val = terra::crs(rx)
+  if (!nzchar(crs_val)) crs_val = 4326
+  spx = rSHUD::fishnet(xx=xx, yy=yy, crs=crs_val)
   return(spx)
 }


### PR DESCRIPTION
## Problem
`xyz2Raster` (rSHUD 2.1.0) creates `SpatRaster` without setting CRS → `terra::crs()` returns `""` → `fishnet`'s `.rshud_as_crs` rejects empty strings (`nzchar("") == FALSE`).

## Fix
Default to EPSG:4326 when CRS is unset. This matches the CMFD/LDAS data convention (GCS lon/lat).

## Testing
Validated by running QHH baseline Step2 CMFD forcing pipeline.