### PR TITLE
fix: terra compat — replace raster::projectRaster in Fun.Soil_Geol

### DIFF
--- a/Rfunction/Fun.Soil_Geol.R
+++ b/Rfunction/Fun.Soil_Geol.R
@@ -59,9 +59,10 @@ fun.Soil_Geol <- function(fn.r, fn.tab, TOP=TRUE,
   }
   
   write.df(texture, file=fatt)
-  r2 = raster::projectRaster(r1, crs=xfg$crs.pcs)
   raster::writeRaster(r1, filename = fp, overwrite=TRUE)
-  raster::writeRaster(r2, filename = fg, overwrite=TRUE)
+  r1t <- terra::rast(r1)
+  r2t <- terra::project(r1t, "EPSG:4326")
+  terra::writeRaster(r2t, filename = fg, overwrite=TRUE)
   texture[is.na(texture) | is.nan(texture)] = -9999
   message(msg, 'Texture: ')
   print(apply(texture, 2, summary))


### PR DESCRIPTION
## 问题

`Fun.Soil_Geol.R:62` 使用 `raster::projectRaster(r1, crs=xfg$crs.pcs)`，在 terra 1.8.x 环境下因 CRS slot 不兼容崩溃：

```
Error in .rawTransform(projfrom, projto, xy) :
  no slot of name "ptr" for this object of class "SpatVector"
```

此外原代码投影方向有误：将 PCS 栅格投影到 PCS（同 CRS），但写入的是 GCS 路径 (`fg`)。

## 修复

- 替换为 `terra::project(r1t, "EPSG:4326")`
- 修正投影方向：PCS → GCS (EPSG:4326)

## 验证（SHUD 服务器环境）

- R 4.3.1 + terra 1.8.86 + raster 3.6-26
- AutoSHUD Step1-3 baseline profile 全部通过
- `qhh.sp.riv` MD5 可复现 (`78763f08`)
- slope vs DEM 真值 cor=1.0，端点偏差 <0.5m